### PR TITLE
Minion: Add examples/basic_pipeline.py + examples/ai_pipeline.py + README quick-start update. ACs: (1) examples/basic_pipeline.py runnable as `python examples/basic_pipeline.py` from repo root — 3 stages fetch (canned dict) → summarize (claude_stage with {fetch}) → deliver (writes to /tmp/stagehand-demo-out.txt); pipeline_id includes today's date; falls back to a stub stage if neither anthropic SDK nor claude CLI is available; uses if __name__=='__main__' guard. (2) examples/ai_pipeline.py is a v0.3.0 PREVIEW stub — try/except imports of AgentPipeline so file imports cleanly today; on run, prints intended usage + 'Coming in v0.3.0'. (3) README.md replaces the empty 'Static pipeline' code block with a one-liner pointing to examples/basic_pipeline.py. (4) No new deps in pyproject.toml. Files: examples/basic_pipeline.py (new), examples/ai_pipeline.py (new), README.md (update). Deps: none. Full plan in SPRINT-PLAN.md Slot 1.

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,15 +28,7 @@ It's the missing layer between "run a script" and "deploy Airflow."
 
 ### Static pipeline (known workflow)
 
-```python
-from stagehand import Pipeline, claude_stage
-
-p = Pipeline("weekly-content")
-p.stage("fetch",    fetch_from_notion)
-p.stage("generate", claude_stage("Write a LinkedIn post about: {fetch}"), deps=["fetch"])
-p.stage("deliver",  send_to_telegram, deps=["generate"])
-p.run()
-```
+See [`examples/basic_pipeline.py`](examples/basic_pipeline.py) for a runnable 3-stage demo (fetch → summarize → deliver) — `python examples/basic_pipeline.py`.
 
 ### Dynamic pipeline (plain-English task)
 


### PR DESCRIPTION
Closes #27

## Minion Execution Log
Blueprint: developer
Iterations: 1
Time: 228s
